### PR TITLE
Only sass build index.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "sass": "sass --watch src/styles/scss:src/styles/css",
-    "sass:build": "sass src/styles/scss:src/styles/css"
+    "sass": "sass --watch src/styles/scss/index.scss:src/styles/css/index.css",
+    "sass:build": "sass src/styles/scss/index.scss:src/styles/css/index.css"
   },
   "proxy": "http://localhost:5000"
 }


### PR DESCRIPTION
This fixes the undefined color warnings. And probably speeds up the
build. This also assumes we're sticking with the all-css-in-index.css
approach, which I think makes sense for now.

Part of my crusade against having compiler warnings/errors in master. I swear I'm also working on the challenge page though lol